### PR TITLE
feat: add custom timelimit range for each engines

### DIFF
--- a/ddgs/ddgs.py
+++ b/ddgs/ddgs.py
@@ -121,7 +121,7 @@ class DDGS:
             query: The search query.
             region: The region to use for the search (e.g., us-en, uk-en, ru-ru, etc.).
             safesearch: The safesearch setting (e.g., on, moderate, off).
-            timelimit: The timelimit for the search (e.g., d, w, m, y).
+            timelimit: The timelimit for the search (e.g., d, w, m, y) or custom date range.
             max_results: The maximum number of results to return. Defaults to 10.
             page: The page of results to return. Defaults to 1.
             backend: A single or comma-delimited backends. Defaults to "auto".

--- a/ddgs/engines/duckduckgo.py
+++ b/ddgs/engines/duckduckgo.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from ..base import BaseSearchEngine
 from ..results import TextResult
+from ..utils import _is_custom_date_range, _parse_date_range
 
 
 class Duckduckgo(BaseSearchEngine[TextResult]):
@@ -27,5 +28,14 @@ class Duckduckgo(BaseSearchEngine[TextResult]):
         if page > 1:
             payload["s"] = f"{10 + (page - 2) * 15}"
         if timelimit:
-            payload["df"] = timelimit
+            if _is_custom_date_range(timelimit):
+                # Handle custom date range: YYYY-MM-DD..YYYY-MM-DD
+                date_range = _parse_date_range(timelimit)
+                if date_range:
+                    start_date, end_date = date_range
+                    # DuckDuckGo uses after:YYYY-MM-DD before:YYYY-MM-DD in query
+                    payload["q"] += f" after:{start_date} before:{end_date}"
+            else:
+                # Handle predefined time limits (d, w, m, y)
+                payload["df"] = timelimit
         return payload

--- a/ddgs/engines/mojeek.py
+++ b/ddgs/engines/mojeek.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from ..base import BaseSearchEngine
 from ..results import TextResult
+from ..utils import _is_custom_date_range, _parse_date_range
 
 
 class Mojeek(BaseSearchEngine[TextResult]):
@@ -23,6 +24,7 @@ class Mojeek(BaseSearchEngine[TextResult]):
         "href": ".//h2/a/@href",
         "body": ".//p[@class='s']//text()",
     }
+    elements_replace = {}  # Required by BaseSearchEngine for XPath-based engines
 
     def build_payload(
         self, query: str, region: str, safesearch: str, timelimit: str | None, page: int = 1, **kwargs: Any
@@ -39,6 +41,14 @@ class Mojeek(BaseSearchEngine[TextResult]):
             payload["safe"] = "1"
         if page > 1:
             payload["s"] = f"{(page - 1) * 10 + 1}"
+        if timelimit and _is_custom_date_range(timelimit):
+            # Handle custom date range: YYYY-MM-DD..YYYY-MM-DD
+            date_range = _parse_date_range(timelimit)
+            if date_range:
+                start_date, end_date = date_range
+                # Mojeek supports custom date ranges in query
+                payload["q"] += f" after:{start_date} before:{end_date}"
+            # Note: Mojeek doesn't have standard predefined time limits like other engines
         # Randomize payload order
         payload = dict(sample(list(payload.items()), len(payload)))
         return payload

--- a/ddgs/engines/yandex.py
+++ b/ddgs/engines/yandex.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from ..base import BaseSearchEngine
 from ..results import TextResult
+from ..utils import _is_custom_date_range, _parse_date_range
 
 
 class Yandex(BaseSearchEngine[TextResult]):
@@ -34,4 +35,12 @@ class Yandex(BaseSearchEngine[TextResult]):
         }
         if page > 1:
             payload["p"] = f"{page - 1}"
+        if timelimit and _is_custom_date_range(timelimit):
+            # Handle custom date range: YYYY-MM-DD..YYYY-MM-DD
+            date_range = _parse_date_range(timelimit)
+            if date_range:
+                start_date, end_date = date_range
+                # Yandex supports custom date ranges in query
+                payload["text"] += f" after:{start_date} before:{end_date}"
+        # Note: Yandex doesn't have standard predefined time limits like other engines
         return payload


### PR DESCRIPTION
#356 
feat: add custom date range (e.g., '2024-01-01..2025-01-01')
fixed: mojeek search