### PR TITLE
Fix(DuckDuckGo): add fake user agent and request headers to HTTP client

### DIFF
--- a/ddgs/engines/duckduckgo.py
+++ b/ddgs/engines/duckduckgo.py
@@ -3,9 +3,13 @@
 from collections.abc import Mapping
 from typing import Any, ClassVar, TypeVar
 
+from fake_useragent import UserAgent
+
 from ddgs.base import BaseSearchEngine
 from ddgs.http_client2 import HttpClient2
 from ddgs.results import TextResult
+
+ua = UserAgent()
 
 T = TypeVar("T")
 
@@ -23,9 +27,11 @@ class Duckduckgo(BaseSearchEngine[TextResult]):
     items_xpath = "//div[contains(@class, 'body')]"
     elements_xpath: ClassVar[Mapping[str, str]] = {"title": ".//h2//text()", "href": "./a/@href", "body": "./a//text()"}
 
+    headers: ClassVar[dict[str, str]] = {"User-Agent": ua.random}
+
     def __init__(self, proxy: str | None = None, timeout: int | None = None, *, verify: bool = True) -> None:
         """Temporary, delete when HttpClient is fixed."""
-        self.http_client = HttpClient2(proxy=proxy, timeout=timeout, verify=verify)  # type: ignore[assignment]
+        self.http_client = HttpClient2(headers=self.headers, proxy=proxy, timeout=timeout, verify=verify)  # type: ignore[assignment]
         self.results: list[T] = []  # type: ignore[valid-type]
 
     def build_payload(

--- a/ddgs/http_client2.py
+++ b/ddgs/http_client2.py
@@ -34,10 +34,18 @@ class Response:
 class HttpClient2:
     """Temporary HTTP client."""
 
-    def __init__(self, proxy: str | None = None, timeout: int | None = 10, *, verify: bool | str = True) -> None:
+    def __init__(
+        self,
+        headers: dict[str, str] | None = None,
+        proxy: str | None = None,
+        timeout: int | None = 10,
+        *,
+        verify: bool | str = True,
+    ) -> None:
         """Initialize the HttpClient object.
 
         Args:
+            headers (dict, optional): headers for the HTTP client.
             proxy (str, optional): proxy for the HTTP client, supports http/https/socks5 protocols.
                 example: "http://user:pass@example.com:3128". Defaults to None.
             timeout (int, optional): Timeout value for the HTTP client. Defaults to 10.
@@ -45,6 +53,7 @@ class HttpClient2:
 
         """
         self.client = httpx.Client(
+            headers=headers,
             proxy=proxy,
             timeout=timeout,
             verify=_get_random_ssl_context(verify=verify) if verify else False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "primp>=0.15.0",
     "lxml>=4.9.4",
     "httpx[http2,socks,brotli]>=0.28.1",  # temporarily
+    "fake-useragent>=2.2.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
- Add fake_useragent to project dependencies.
- Configure HTTP client to include headers with a random fake User-Agent