### PR TITLE
feat: add "hide AI images" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ def images(
     type_image: str | None = None,
     layout: str | None = None,
     license_image: str | None = None,
+    hide_ai_images: bool | None = None,
 ) -> list[dict[str, str]]:
     """DDGS images metasearch.
 
@@ -334,6 +335,7 @@ def images(
             Share (Free to Share and Use), ShareCommercially (Free to Share and Use Commercially),
             Modify (Free to Modify, Share, and Use), ModifyCommercially (Free to Modify, Share, and
             Use Commercially). Defaults to None.
+        hide_ai_images: exclude AI generated images from results.
 
     Returns:
         List of dictionaries with images search results.

--- a/ddgs/cli.py
+++ b/ddgs/cli.py
@@ -295,6 +295,7 @@ def text(
     "--license_image",
     type=click.Choice(["any", "Public", "Share", "ShareCommercially", "Modify", "ModifyCommercially"]),
 )
+@click.option("-hai", "--hide-ai-images", is_flag=True, default=False, help="exclude AI generated images from results")
 @click.option("-o", "--output", help="csv, json or filename.csv|json (save the results to a csv or json file)")
 @click.option("-d", "--download", is_flag=True, default=False, help="download results. -dd to set custom directory")
 @click.option("-dd", "--download-directory", help="Specify custom download directory")
@@ -315,6 +316,7 @@ def images(
     type_image: str | None,
     layout: str | None,
     license_image: str | None,
+    hide_ai_images: bool | None,
     download_directory: str | None,
     threads: int,
     output: str | None,
@@ -338,6 +340,7 @@ def images(
         type_image=type_image,
         layout=layout,
         license_image=license_image,
+        hide_ai_images=hide_ai_images,
     )
     query = _sanitize_query(query)
     if output:

--- a/ddgs/engines/duckduckgo_images.py
+++ b/ddgs/engines/duckduckgo_images.py
@@ -58,6 +58,7 @@ class DuckduckgoImages(BaseSearchEngine[ImagesResult]):
         layout = f"layout:{layout}" if layout else ""
         license_image = kwargs.get("license_image")
         license_image = f"license:{license_image}" if license_image else ""
+        hide_ai_images = "hide_ai_images:1" if kwargs.get("hide_ai_images") else ""
         payload = {
             "o": "json",
             "q": query,
@@ -66,7 +67,7 @@ class DuckduckgoImages(BaseSearchEngine[ImagesResult]):
             "p": safesearch_base[safesearch.lower()],
         }
         if timelimit or size or color or type_image or layout or license_image:
-            payload["f"] = f"{timelimit},{size},{color},{type_image},{layout},{license_image}"
+            payload["f"] = f"{timelimit},{size},{color},{type_image},{layout},{license_image},{hide_ai_images}"
         if page > 1:
             payload["s"] = f"{(page - 1) * 100}"
         return payload


### PR DESCRIPTION
This PR adds support for the "hide AI images" option in DuckDuckGo image search, documented here:
https://duckduckgo.com/duckduckgo-help-pages/results/how-to-filter-out-ai-images-in-duckduckgo-search-results