### PR TITLE
fix(http_client): serialize primp.Client construction to avoid first-call deadlock

### DIFF
--- a/ddgs/http_client.py
+++ b/ddgs/http_client.py
@@ -1,6 +1,7 @@
 """HTTP client."""
 
 import logging
+import threading
 from typing import Any
 
 import primp
@@ -8,6 +9,15 @@ import primp
 from .exceptions import DDGSException, TimeoutException
 
 logger = logging.getLogger(__name__)
+
+# Serialize primp.Client construction to avoid a first-call init race:
+# when several threads construct primp.Client(impersonate="random", ...)
+# concurrently, a deadlock can occur between Python's logging._lock and
+# an internal Rust mutex (lazy-init of the browser-fingerprint data).
+# Construction is short (microseconds after the first call), so the
+# overhead of a process-global lock is negligible; it only matters for
+# the very first concurrent init.
+_PRIMP_CLIENT_INIT_LOCK = threading.Lock()
 
 
 class Response:
@@ -50,14 +60,15 @@ class HttpClient:
             verify: (bool | str):  True to verify, False to skip, or a str path to a PEM file. Defaults to True.
 
         """
-        self.client = primp.Client(
-            proxy=proxy,
-            timeout=timeout,
-            impersonate="random",
-            impersonate_os="random",
-            verify=verify if isinstance(verify, bool) else True,
-            ca_cert_file=verify if isinstance(verify, str) else None,
-        )
+        with _PRIMP_CLIENT_INIT_LOCK:
+            self.client = primp.Client(
+                proxy=proxy,
+                timeout=timeout,
+                impersonate="random",
+                impersonate_os="random",
+                verify=verify if isinstance(verify, bool) else True,
+                ca_cert_file=verify if isinstance(verify, str) else None,
+            )
 
     def request(self, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
         """Make a request to the HTTP client."""


### PR DESCRIPTION
## Summary

Guards `primp.Client(...)` construction in `HttpClient.__init__` with a process-global `threading.Lock` to break a first-call deadlock that occurs when several `HttpClient` are constructed concurrently from multiple threads — the typical pattern when users call `DDGS().text(...)` from parallel `asyncio.to_thread` tasks.

## Reproduction

```python
# Hangs indefinitely on ddgs 9.13 / 9.14 + primp 1.2.x
import asyncio
from ddgs import DDGS

async def run():
    return await asyncio.gather(*[
        asyncio.to_thread(DDGS().text, q, region="de-de", max_results=10)
        for q in ["query a", "query b", "query c", "query d"]
    ])

asyncio.run(run())   # never returns
```

A [faulthandler](https://docs.python.org/3/library/faulthandler.html) dump taken after 30 s shows multiple worker threads stuck inside `ddgs/http_client.py:53` at `primp.Client(impersonate="random", ...)`, with one additional thread blocked in `logging/__init__.py:2130` → `getLogger` → `_lock`.

That's the signature of a classic ordering deadlock between Python's `logging._lock` and an internal Rust mutex owned by primp — triggered on the lazy-init path of the browser-fingerprint data, which runs the first time any `primp.Client(impersonate="random", ...)` is constructed.

- `requests`/primp `timeout` is inter-byte only, so it cannot break the hang.
- `asyncio.to_thread` cannot cancel OS threads, so `asyncio.wait_for` around it only releases the await — the thread stays stuck until the process dies.
- The symptom propagates: the default `ThreadPoolExecutor` fills with stuck threads, further `asyncio.to_thread` submits queue, and in FastAPI/uvicorn deployments the entire event loop can appear frozen to the outside (every endpoint, including a trivial `/alive`, times out until the primp threads eventually die).

## Fix

Wrap the `primp.Client(...)` call in `HttpClient.__init__` with a module-level `threading.Lock`. That serializes **only the constructor**; once Rust-side statics are warm, the lock contention is negligible. Overhead is microseconds and occurs exactly once per process in practice.

## Verification

With the reproducer above:
- **Before:** hangs for the full test timeout (90+ s, verified stuck for 8 min).
- **After:** 4 concurrent `DDGS().text()` calls complete in ~1.5 s.

Existing test suite (`pytest tests/ddgs_test.py tests/cli_test.py`): **17/17 pass** (50.8 s).

## Related issues

- HKUDS/nanobot#2804 / HKUDS/nanobot#2805 — same root symptom, addressed consumer-side with an `asyncio.wait_for(...)` wrap. That workaround does not fix the underlying race; it only prevents consumer apps from hanging forever. This PR fixes the root cause inside ddgs so downstream consumers do not need the wrap.
- deedy5/ddgs#427 — different surface (successful-backend results dropped on exception), but also concurrent-backend-related.

Happy to iterate on the comment style or naming of the lock variable if preferred.