### PR TITLE
fix(DuckDuckGo): correct search method and clean up URL

### DIFF
--- a/ddgs/engines/duckduckgo.py
+++ b/ddgs/engines/duckduckgo.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Mapping
 from typing import Any, ClassVar
+from urllib.parse import parse_qs, urlsplit
 
 from ddgs.base import BaseSearchEngine
 from ddgs.results import TextResult
@@ -15,7 +16,7 @@ class Duckduckgo(BaseSearchEngine[TextResult]):
     provider = "bing"
 
     search_url = "https://html.duckduckgo.com/html/"
-    search_method = "POST"
+    search_method = "GET"
 
     items_xpath = "//div[contains(@class, 'body')]"
     elements_xpath: ClassVar[Mapping[str, str]] = {"title": ".//h2//text()", "href": "./a/@href", "body": "./a//text()"}
@@ -39,4 +40,15 @@ class Duckduckgo(BaseSearchEngine[TextResult]):
 
     def post_extract_results(self, results: list[TextResult]) -> list[TextResult]:
         """Post-process search results."""
-        return [r for r in results if not r.href.startswith("https://duckduckgo.com/y.js?")]
+        processed_results = []
+        for result in results:
+            if result.href.startswith("https://duckduckgo.com/y.js?"):
+                continue
+
+            if result.href.startswith("//duckduckgo.com/l/?") or result.href.startswith("https://duckduckgo.com/l/?"):
+                query_params = parse_qs(urlsplit(result.href).query)
+                result.href = query_params.get("uddg", [result.href])[0]
+
+            processed_results.append(result)
+
+        return processed_results


### PR DESCRIPTION
Using `POST` method always give empty results for me while `GET` works. DuckDuckGo also sometimes return URLs wrapped in `uddg` that needs to be cleaned up.