### PR TITLE
remove grokipedia from "auto"

### DIFF
--- a/ddgs/ddgs.py
+++ b/ddgs/ddgs.py
@@ -309,7 +309,7 @@ class DDGS:
         if "auto" in backend_list or "all" in backend_list:
             keys = engine_keys
             if category == "text":
-                keys = ["wikipedia", "grokipedia"] + [k for k in keys if k not in ("wikipedia", "grokipedia")]
+                keys = ["wikipedia"] + [k for k in keys if k not in ("wikipedia", "grokipedia")]
         else:
             keys = backend_list
 


### PR DESCRIPTION
While I understand the desire to add grokipedia as a supported search target, I do not believe it should be included in "auto" (and even prioritized over other platforms).