### PR TITLE
fix: resolve Windows GBK encoding issue in CLI output

### DIFF
--- a/ddgs/cli.py
+++ b/ddgs/cli.py
@@ -166,6 +166,13 @@ def cli() -> None:
 def safe_entry_point() -> None:
     """Run the CLI tool in try-except block to catch all exceptions."""
     logging.basicConfig(level=logging.WARNING)
+    # Fix Windows GBK encoding issues by setting stdout to UTF-8
+    if sys.platform == "win32" and hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8")
+            sys.stderr.reconfigure(encoding="utf-8")
+        except Exception:  # noqa: BLE001
+            pass  # Fallback to original encoding if reconfigure fails
     try:
         cli()
     except Exception as ex:  # noqa: BLE001

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -45,6 +45,12 @@ def test_books_command() -> None:
     assert "title" in result.output
 
 
+def test_extract_command() -> None:
+    result = runner.invoke(cli, ["extract", "-u", "https://www.technologyreview.com/2026/01/12/1130697/10-breakthrough-technologies-2026/"])
+    assert result.exit_code == 0
+    assert "Breakthrough" in result.output
+
+
 def test_text_workflow(tmp_path: Path) -> None:
     """Combined test for text search, save, and download functionality."""
     # Step 1: Get text results


### PR DESCRIPTION
## Summary

Fixes UnicodeEncodeError when running ddgs CLI commands on Windows with GBK console encoding.

## Changes

- Set stdout/stderr to UTF-8 encoding in `safe_entry_point()`
- Fixes UnicodeEncodeError when output contains special Unicode characters (e.g., Arabic characters, Chinese characters, trademark symbols ™)
- Only applies on Windows when `sys.stdout.reconfigure()` is available
- Add test case for extract command

## Problem

On Windows, the default console encoding is GBK. When ddgs CLI outputs results containing characters that can't be encoded in GBK (like Arabic characters, Chinese characters, or special symbols), it crashes with:

```
UnicodeEncodeError: 'gbk' codec can't encode character 'ع' in position 61: illegal multibyte sequence
```

## Solution

Instead of adding exception handling to every `click.secho()` call, we set the stdout/stderr encoding to UTF-8 at the program entry point in `safe_entry_point()`. This is a cleaner, more comprehensive solution that:

1. Fixes the encoding issue for all CLI commands at once
2. Doesn't require modifying individual output functions
3. Falls back gracefully if `reconfigure()` is not available

```python
if sys.platform == "win32" and hasattr(sys.stdout, "reconfigure"):
    try:
        sys.stdout.reconfigure(encoding="utf-8")
        sys.stderr.reconfigure(encoding="utf-8")
    except Exception:
        pass
```

## Testing

- All 9 CLI tests pass
- Added `test_extract_command` test case
- Verified with Chinese characters, Arabic characters, and special symbols